### PR TITLE
[helm for werf] Make cmd package exportable

### DIFF
--- a/cmd/helm/chart.go
+++ b/cmd/helm/chart.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/chart_export.go
+++ b/cmd/helm/chart_export.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/chart_list.go
+++ b/cmd/helm/chart_list.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/chart_pull.go
+++ b/cmd/helm/chart_pull.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/chart_push.go
+++ b/cmd/helm/chart_push.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/chart_remove.go
+++ b/cmd/helm/chart_remove.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/chart_save.go
+++ b/cmd/helm/chart_save.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/completion.go
+++ b/cmd/helm/completion.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/create.go
+++ b/cmd/helm/create.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/create_test.go
+++ b/cmd/helm/create_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/dependency.go
+++ b/cmd/helm/dependency.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/dependency_build.go
+++ b/cmd/helm/dependency_build.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/dependency_build_test.go
+++ b/cmd/helm/dependency_build_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/dependency_test.go
+++ b/cmd/helm/dependency_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"runtime"

--- a/cmd/helm/dependency_update.go
+++ b/cmd/helm/dependency_update.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/dependency_update_test.go
+++ b/cmd/helm/dependency_update_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/docs.go
+++ b/cmd/helm/docs.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/env.go
+++ b/cmd/helm/env.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/exports.go
+++ b/cmd/helm/exports.go
@@ -1,0 +1,32 @@
+package helm_v3
+
+var (
+	Settings = settings
+
+	InitKubeLogs         = initKubeLogs
+	LoadReleasesInMemory = loadReleasesInMemory
+	Debug                = debug
+	NewRootCmd           = newRootCmd
+
+	NewUninstallCmd  = newUninstallCmd
+	NewDependencyCmd = newDependencyCmd
+	NewGetCmd        = newGetCmd
+	NewHistoryCmd    = newHistoryCmd
+	NewLintCmd       = newLintCmd
+	NewListCmd       = newListCmd
+	NewTemplateCmd   = newTemplateCmd
+	NewRepoCmd       = newRepoCmd
+	NewRollbackCmd   = newRollbackCmd
+	NewInstallCmd    = newInstallCmd
+	NewUpgradeCmd    = newUpgradeCmd
+	NewCreateCmd     = newCreateCmd
+	NewEnvCmd        = newEnvCmd
+	NewPackageCmd    = newPackageCmd
+	NewPluginCmd     = newPluginCmd
+	NewPullCmd       = newPullCmd
+	NewSearchCmd     = newSearchCmd
+	NewShowCmd       = newShowCmd
+	NewStatusCmd     = newStatusCmd
+	NewTestCmd       = newReleaseTestCmd
+	NewVerifyCmd     = newVerifyCmd
+)

--- a/cmd/helm/flags.go
+++ b/cmd/helm/flags.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/flags_test.go
+++ b/cmd/helm/flags_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/get.go
+++ b/cmd/helm/get.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/get_all.go
+++ b/cmd/helm/get_all.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/get_all_test.go
+++ b/cmd/helm/get_all_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"testing"

--- a/cmd/helm/get_hooks.go
+++ b/cmd/helm/get_hooks.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/get_hooks_test.go
+++ b/cmd/helm/get_hooks_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"testing"

--- a/cmd/helm/get_manifest.go
+++ b/cmd/helm/get_manifest.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/get_manifest_test.go
+++ b/cmd/helm/get_manifest_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"testing"

--- a/cmd/helm/get_notes.go
+++ b/cmd/helm/get_notes.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/get_notes_test.go
+++ b/cmd/helm/get_notes_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"testing"

--- a/cmd/helm/get_values.go
+++ b/cmd/helm/get_values.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/get_values_test.go
+++ b/cmd/helm/get_values_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"testing"

--- a/cmd/helm/helm.go
+++ b/cmd/helm/helm.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main // import "helm.sh/helm/v3/cmd/helm"
+package helm_v3 // import "helm.sh/helm/v3/cmd/helm"
 
 import (
 	"flag"

--- a/cmd/helm/helm_test.go
+++ b/cmd/helm/helm_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"bytes"

--- a/cmd/helm/history.go
+++ b/cmd/helm/history.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/history_test.go
+++ b/cmd/helm/history_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/install_test.go
+++ b/cmd/helm/install_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"testing"

--- a/cmd/helm/lint.go
+++ b/cmd/helm/lint.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/lint_test.go
+++ b/cmd/helm/lint_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/list.go
+++ b/cmd/helm/list.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/list_test.go
+++ b/cmd/helm/list_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"testing"

--- a/cmd/helm/load_plugins.go
+++ b/cmd/helm/load_plugins.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"bytes"

--- a/cmd/helm/package.go
+++ b/cmd/helm/package.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/package_test.go
+++ b/cmd/helm/package_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"bytes"

--- a/cmd/helm/plugin.go
+++ b/cmd/helm/plugin.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/plugin_install.go
+++ b/cmd/helm/plugin_install.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/plugin_list.go
+++ b/cmd/helm/plugin_list.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/plugin_test.go
+++ b/cmd/helm/plugin_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"bytes"

--- a/cmd/helm/plugin_uninstall.go
+++ b/cmd/helm/plugin_uninstall.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/plugin_update.go
+++ b/cmd/helm/plugin_update.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/printer.go
+++ b/cmd/helm/printer.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/pull.go
+++ b/cmd/helm/pull.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/pull_test.go
+++ b/cmd/helm/pull_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/registry.go
+++ b/cmd/helm/registry.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/registry_login.go
+++ b/cmd/helm/registry_login.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"bufio"

--- a/cmd/helm/registry_logout.go
+++ b/cmd/helm/registry_logout.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/release_testing.go
+++ b/cmd/helm/release_testing.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/repo.go
+++ b/cmd/helm/repo.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/repo_add.go
+++ b/cmd/helm/repo_add.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"context"

--- a/cmd/helm/repo_add_test.go
+++ b/cmd/helm/repo_add_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/repo_index.go
+++ b/cmd/helm/repo_index.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/repo_index_test.go
+++ b/cmd/helm/repo_index_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"bytes"

--- a/cmd/helm/repo_list.go
+++ b/cmd/helm/repo_list.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/repo_list_test.go
+++ b/cmd/helm/repo_list_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"testing"

--- a/cmd/helm/repo_remove.go
+++ b/cmd/helm/repo_remove.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/repo_remove_test.go
+++ b/cmd/helm/repo_remove_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"bytes"

--- a/cmd/helm/repo_update.go
+++ b/cmd/helm/repo_update.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/repo_update_test.go
+++ b/cmd/helm/repo_update_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"bytes"

--- a/cmd/helm/rollback.go
+++ b/cmd/helm/rollback.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/rollback_test.go
+++ b/cmd/helm/rollback_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"testing"

--- a/cmd/helm/root.go
+++ b/cmd/helm/root.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main // import "helm.sh/helm/v3/cmd/helm"
+package helm_v3 // import "helm.sh/helm/v3/cmd/helm"
 
 import (
 	"context"
@@ -70,7 +70,7 @@ By default, the default directories depend on the Operating System. The defaults
 
 func newRootCmd(actionConfig *action.Configuration, out io.Writer, args []string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                    "helm",
+		Use:                    "helm-v3",
 		Short:                  "The Helm package manager for Kubernetes.",
 		Long:                   globalUsage,
 		SilenceUsage:           true,

--- a/cmd/helm/root_test.go
+++ b/cmd/helm/root_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"os"

--- a/cmd/helm/search.go
+++ b/cmd/helm/search.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"io"

--- a/cmd/helm/search_hub.go
+++ b/cmd/helm/search_hub.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/search_hub_test.go
+++ b/cmd/helm/search_hub_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/search_repo.go
+++ b/cmd/helm/search_repo.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"bufio"

--- a/cmd/helm/search_repo_test.go
+++ b/cmd/helm/search_repo_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"testing"

--- a/cmd/helm/show.go
+++ b/cmd/helm/show.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/show_test.go
+++ b/cmd/helm/show_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/status_test.go
+++ b/cmd/helm/status_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"testing"

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"bytes"

--- a/cmd/helm/template_test.go
+++ b/cmd/helm/template_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/uninstall.go
+++ b/cmd/helm/uninstall.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/uninstall_test.go
+++ b/cmd/helm/uninstall_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"testing"

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/upgrade_test.go
+++ b/cmd/helm/upgrade_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/verify.go
+++ b/cmd/helm/verify.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/verify_test.go
+++ b/cmd/helm/verify_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/version.go
+++ b/cmd/helm/version.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"fmt"

--- a/cmd/helm/version_test.go
+++ b/cmd/helm/version_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package helm_v3
 
 import (
 	"testing"

--- a/pkg/cli/exports.go
+++ b/pkg/cli/exports.go
@@ -1,0 +1,5 @@
+package cli
+
+func (s *EnvSettings) GetNamespaceP() *string {
+	return &s.namespace
+}


### PR DESCRIPTION
 - change "main" package name to "helm_v3";
 - make all top-level helm commands constructors exportable for helm_v3 package.