### PR TITLE
[helm for werf] More exports and additions

### DIFF
--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -106,7 +106,8 @@ charts in a repository, use 'helm search'.
 `
 
 func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
-	return NewInstallCmd(cfg, out, InstallCmdOptions{})
+	cmd, _ := NewInstallCmd(cfg, out, InstallCmdOptions{})
+	return cmd
 }
 
 type InstallCmdOptions struct {
@@ -114,7 +115,7 @@ type InstallCmdOptions struct {
 	ValueOpts    *values.Options
 }
 
-func NewInstallCmd(cfg *action.Configuration, out io.Writer, opts InstallCmdOptions) *cobra.Command {
+func NewInstallCmd(cfg *action.Configuration, out io.Writer, opts InstallCmdOptions) (*cobra.Command, *action.Install) {
 	client := action.NewInstall(cfg)
 	client.PostRenderer = opts.PostRenderer
 	valueOpts := &values.Options{}
@@ -148,7 +149,7 @@ func NewInstallCmd(cfg *action.Configuration, out io.Writer, opts InstallCmdOpti
 	bindOutputFlag(cmd, &outfmt)
 	bindPostRenderFlag(cmd, &client.PostRenderer)
 
-	return cmd
+	return cmd, client
 }
 
 func addInstallFlags(f *pflag.FlagSet, client *action.Install, valueOpts *values.Options) {

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -111,12 +111,16 @@ func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 
 type InstallCmdOptions struct {
 	PostRenderer postrender.PostRenderer
+	ValueOpts    *values.Options
 }
 
 func NewInstallCmd(cfg *action.Configuration, out io.Writer, opts InstallCmdOptions) *cobra.Command {
 	client := action.NewInstall(cfg)
 	client.PostRenderer = opts.PostRenderer
 	valueOpts := &values.Options{}
+	if opts.ValueOpts != nil {
+		valueOpts = opts.ValueOpts
+	}
 	var outfmt output.Format
 
 	cmd := &cobra.Command{
@@ -125,6 +129,7 @@ func NewInstallCmd(cfg *action.Configuration, out io.Writer, opts InstallCmdOpti
 		Long:  installDesc,
 		Args:  require.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
+			fmt.Printf("!!! valueOpts = %#v\n", *valueOpts)
 			rel, err := runInstall(args, client, valueOpts, out)
 			if err != nil {
 				return err

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -68,12 +68,16 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 
 type UpgradeCmdOptions struct {
 	PostRenderer postrender.PostRenderer
+	ValueOpts    *values.Options
 }
 
 func NewUpgradeCmd(cfg *action.Configuration, out io.Writer, opts UpgradeCmdOptions) *cobra.Command {
 	client := action.NewUpgrade(cfg)
 	client.PostRenderer = opts.PostRenderer
 	valueOpts := &values.Options{}
+	if opts.ValueOpts != nil {
+		valueOpts = opts.ValueOpts
+	}
 	var outfmt output.Format
 	var createNamespace bool
 
@@ -83,6 +87,7 @@ func NewUpgradeCmd(cfg *action.Configuration, out io.Writer, opts UpgradeCmdOpti
 		Long:  upgradeDesc,
 		Args:  require.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Printf("!!! valueOpts = %#v\n", *valueOpts)
 			client.Namespace = settings.Namespace()
 
 			// Fixes #7002 - Support reading values from STDIN for `upgrade` command

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -63,7 +63,8 @@ set for a key called 'foo', the 'newbar' value would take precedence:
 `
 
 func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
-	return NewUpgradeCmd(cfg, out, UpgradeCmdOptions{})
+	cmd, _ := NewUpgradeCmd(cfg, out, UpgradeCmdOptions{})
+	return cmd
 }
 
 type UpgradeCmdOptions struct {
@@ -71,7 +72,7 @@ type UpgradeCmdOptions struct {
 	ValueOpts    *values.Options
 }
 
-func NewUpgradeCmd(cfg *action.Configuration, out io.Writer, opts UpgradeCmdOptions) *cobra.Command {
+func NewUpgradeCmd(cfg *action.Configuration, out io.Writer, opts UpgradeCmdOptions) (*cobra.Command, *action.Upgrade) {
 	client := action.NewUpgrade(cfg)
 	client.PostRenderer = opts.PostRenderer
 	valueOpts := &values.Options{}
@@ -205,5 +206,5 @@ func NewUpgradeCmd(cfg *action.Configuration, out io.Writer, opts UpgradeCmdOpti
 	bindOutputFlag(cmd, &outfmt)
 	bindPostRenderFlag(cmd, &client.PostRenderer)
 
-	return cmd
+	return cmd, client
 }

--- a/pkg/cli/values/options.go
+++ b/pkg/cli/values/options.go
@@ -30,10 +30,12 @@ import (
 )
 
 type Options struct {
-	ValueFiles   []string
-	StringValues []string
-	Values       []string
-	FileValues   []string
+	ValueFiles        []string
+	RawValues         []map[string]interface{}
+	StringValues      []string
+	Values            []string
+	FileValues        []string
+	RawValuesOverride []map[string]interface{}
 }
 
 // MergeValues merges values from files specified via -f/--values and directly
@@ -55,6 +57,10 @@ func (opts *Options) MergeValues(p getter.Providers) (map[string]interface{}, er
 		}
 		// Merge with the previous map
 		base = mergeMaps(base, currentMap)
+	}
+
+	for _, rawValues := range opts.RawValues {
+		base = mergeMaps(base, rawValues)
 	}
 
 	// User specified a value via --set
@@ -80,6 +86,10 @@ func (opts *Options) MergeValues(p getter.Providers) (map[string]interface{}, er
 		if err := strvals.ParseIntoFile(value, base, reader); err != nil {
 			return nil, errors.Wrap(err, "failed parsing --set-file data")
 		}
+	}
+
+	for _, rawValues := range opts.RawValuesOverride {
+		base = mergeMaps(base, rawValues)
 	}
 
 	return base, nil


### PR DESCRIPTION
[helm for werf] Return action struct for install / upgrade commands
[helm for werf] Support RawValues and RawValuesOverride for ValueOptions to pass map of values directly without CLI-params
[helm for werf] Export ValueOpts option for Install / Upgrade
