### PR TITLE
[helm for werf] Added ChartExtender support into Chart to implement WerfChart extensions

### DIFF
--- a/cmd/helm/chart_save.go
+++ b/cmd/helm/chart_save.go
@@ -35,6 +35,14 @@ not change the item as it exists in the cache.
 `
 
 func newChartSaveCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
+	return NewChartSaveCmd(cfg, out, ChartSaveCmdOptions{})
+}
+
+type ChartSaveCmdOptions struct {
+	LoadOptions loader.LoadOptions
+}
+
+func NewChartSaveCmd(cfg *action.Configuration, out io.Writer, opts ChartSaveCmdOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:    "save [path] [ref]",
 		Short:  "save a chart directory",
@@ -50,7 +58,7 @@ func newChartSaveCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				return err
 			}
 
-			ch, err := loader.Load(path)
+			ch, err := loader.Load(path, opts.LoadOptions)
 			if err != nil {
 				return err
 			}

--- a/cmd/helm/create_test.go
+++ b/cmd/helm/create_test.go
@@ -48,7 +48,7 @@ func TestCreateCmd(t *testing.T) {
 		t.Fatalf("chart is not directory")
 	}
 
-	c, err := loader.LoadDir(cname)
+	c, err := loader.LoadDir(cname, loader.LoadOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestCreateStarterCmd(t *testing.T) {
 		t.Fatalf("chart is not directory")
 	}
 
-	c, err := loader.LoadDir(cname)
+	c, err := loader.LoadDir(cname, loader.LoadOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +162,7 @@ func TestCreateStarterAbsoluteCmd(t *testing.T) {
 		t.Fatalf("chart is not directory")
 	}
 
-	c, err := loader.LoadDir(cname)
+	c, err := loader.LoadDir(cname, loader.LoadOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/helm/exports.go
+++ b/cmd/helm/exports.go
@@ -1,5 +1,11 @@
 package helm_v3
 
+import (
+	"io"
+
+	"helm.sh/helm/v3/internal/experimental/registry"
+)
+
 var (
 	Settings = settings
 
@@ -14,22 +20,32 @@ var (
 	NewHistoryCmd    = newHistoryCmd
 	NewLintCmd       = newLintCmd
 	NewListCmd       = newListCmd
-	NewTemplateCmd   = newTemplateCmd
 	NewRepoCmd       = newRepoCmd
 	NewRollbackCmd   = newRollbackCmd
+	NewCreateCmd     = newCreateCmd
+	NewEnvCmd        = newEnvCmd
+	NewPackageCmd    = newPackageCmd
+	NewPluginCmd     = newPluginCmd
+	NewPullCmd       = newPullCmd
+	NewSearchCmd     = newSearchCmd
+	NewShowCmd       = newShowCmd
+	NewStatusCmd     = newStatusCmd
+	NewTestCmd       = newReleaseTestCmd
+	NewVerifyCmd     = newVerifyCmd
+	NewVersionCmd    = newVersionCmd
+	NewChartCmd      = newChartCmd
+
+	// NOTE: following commands has additional options param and defined in corresponding command files
+	//NewTemplateCmd   = newTemplateCmd
 	//NewInstallCmd    = newInstallCmd
 	//NewUpgradeCmd    = newUpgradeCmd
-	NewCreateCmd  = newCreateCmd
-	NewEnvCmd     = newEnvCmd
-	NewPackageCmd = newPackageCmd
-	NewPluginCmd  = newPluginCmd
-	NewPullCmd    = newPullCmd
-	NewSearchCmd  = newSearchCmd
-	NewShowCmd    = newShowCmd
-	NewStatusCmd  = newStatusCmd
-	NewTestCmd    = newReleaseTestCmd
-	NewVerifyCmd  = newVerifyCmd
-	NewVersionCmd = newVersionCmd
 
 	LoadPlugins = loadPlugins
 )
+
+func NewRegistryClient(debug bool, out io.Writer) (*registry.Client, error) {
+	return registry.NewClient(
+		registry.ClientOptDebug(debug),
+		registry.ClientOptWriter(out),
+	)
+}

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -135,11 +135,9 @@ func NewInstallCmd(cfg *action.Configuration, out io.Writer, opts InstallCmdOpti
 			}
 			if opts.ValueOpts != nil {
 				valueOpts.ValueFiles = append(valueOpts.ValueFiles, opts.ValueOpts.ValueFiles...)
-				valueOpts.RawValues = append(valueOpts.RawValues, opts.ValueOpts.RawValues...)
 				valueOpts.StringValues = append(valueOpts.StringValues, opts.ValueOpts.StringValues...)
 				valueOpts.Values = append(valueOpts.Values, opts.ValueOpts.Values...)
 				valueOpts.FileValues = append(valueOpts.FileValues, opts.ValueOpts.FileValues...)
-				valueOpts.RawValuesOverride = append(valueOpts.RawValuesOverride, opts.ValueOpts.RawValuesOverride...)
 			}
 			if opts.CreateNamespace != nil {
 				client.CreateNamespace = *opts.CreateNamespace

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -111,6 +111,7 @@ func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 }
 
 type InstallCmdOptions struct {
+	LoadOptions     loader.LoadOptions
 	PostRenderer    postrender.PostRenderer
 	ValueOpts       *values.Options
 	CreateNamespace *bool
@@ -150,7 +151,7 @@ func NewInstallCmd(cfg *action.Configuration, out io.Writer, opts InstallCmdOpti
 				client.Atomic = *opts.Atomic
 			}
 
-			rel, err := runInstall(args, client, valueOpts, out)
+			rel, err := runInstall(args, client, valueOpts, out, opts.LoadOptions)
 			if err != nil {
 				return err
 			}
@@ -191,7 +192,7 @@ func addInstallFlags(f *pflag.FlagSet, client *action.Install, valueOpts *values
 	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 }
 
-func runInstall(args []string, client *action.Install, valueOpts *values.Options, out io.Writer) (*release.Release, error) {
+func runInstall(args []string, client *action.Install, valueOpts *values.Options, out io.Writer, loadOpts loader.LoadOptions) (*release.Release, error) {
 	debug("Original chart version: %q", client.Version)
 	if client.Version == "" && client.Devel {
 		debug("setting version to >0.0.0-0")
@@ -218,7 +219,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 	}
 
 	// Check chart dependencies to make sure all are present in /charts
-	chartRequested, err := loader.Load(cp)
+	chartRequested, err := loader.Load(cp, loadOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +253,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 					return nil, err
 				}
 				// Reload the chart with the updated Chart.lock file.
-				if chartRequested, err = loader.Load(cp); err != nil {
+				if chartRequested, err = loader.Load(cp, loadOpts); err != nil {
 					return nil, errors.Wrap(err, "failed reloading chart after repo update")
 				}
 			} else {

--- a/cmd/helm/package_test.go
+++ b/cmd/helm/package_test.go
@@ -187,7 +187,7 @@ func TestSetAppVersion(t *testing.T) {
 	} else if fi.Size() == 0 {
 		t.Errorf("file %q has zero bytes.", chartPath)
 	}
-	ch, err := loader.Load(chartPath)
+	ch, err := loader.Load(chartPath, loader.LoadOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error loading packaged chart: %v", err)
 	}

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -25,6 +25,8 @@ import (
 	"sort"
 	"strings"
 
+	"helm.sh/helm/v3/pkg/chart/loader"
+
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v3/cmd/helm/require"
@@ -44,6 +46,14 @@ faked locally. Additionally, none of the server-side testing of chart validity
 `
 
 func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
+	return NewTemplateCmd(cfg, out, TemplateCmdOptions{})
+}
+
+type TemplateCmdOptions struct {
+	LoadOptions loader.LoadOptions
+}
+
+func NewTemplateCmd(cfg *action.Configuration, out io.Writer, opts TemplateCmdOptions) *cobra.Command {
 	var validate bool
 	var includeCrds bool
 	client := action.NewInstall(cfg)
@@ -63,7 +73,7 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			client.ClientOnly = !validate
 			client.APIVersions = chartutil.VersionSet(extraAPIs)
 			client.IncludeCRDs = includeCrds
-			rel, err := runInstall(args, client, valueOpts, out)
+			rel, err := runInstall(args, client, valueOpts, out, opts.LoadOptions)
 
 			if err != nil && !settings.Debug {
 				if rel != nil {

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -68,6 +68,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 }
 
 type UpgradeCmdOptions struct {
+	LoadOptions     loader.LoadOptions
 	PostRenderer    postrender.PostRenderer
 	ValueOpts       *values.Options
 	CreateNamespace *bool
@@ -140,7 +141,7 @@ func NewUpgradeCmd(cfg *action.Configuration, out io.Writer, opts UpgradeCmdOpti
 					instClient.DisableOpenAPIValidation = client.DisableOpenAPIValidation
 					instClient.SubNotes = client.SubNotes
 
-					rel, err := runInstall(args, instClient, valueOpts, out)
+					rel, err := runInstall(args, instClient, valueOpts, out, opts.LoadOptions)
 					if err != nil {
 						return err
 					}
@@ -166,7 +167,7 @@ func NewUpgradeCmd(cfg *action.Configuration, out io.Writer, opts UpgradeCmdOpti
 			}
 
 			// Check chart dependencies to make sure all are present in /charts
-			ch, err := loader.Load(chartPath)
+			ch, err := loader.Load(chartPath, opts.LoadOptions)
 			if err != nil {
 				return err
 			}

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -94,11 +94,9 @@ func NewUpgradeCmd(cfg *action.Configuration, out io.Writer, opts UpgradeCmdOpti
 			}
 			if opts.ValueOpts != nil {
 				valueOpts.ValueFiles = append(valueOpts.ValueFiles, opts.ValueOpts.ValueFiles...)
-				valueOpts.RawValues = append(valueOpts.RawValues, opts.ValueOpts.RawValues...)
 				valueOpts.StringValues = append(valueOpts.StringValues, opts.ValueOpts.StringValues...)
 				valueOpts.Values = append(valueOpts.Values, opts.ValueOpts.Values...)
 				valueOpts.FileValues = append(valueOpts.FileValues, opts.ValueOpts.FileValues...)
-				valueOpts.RawValuesOverride = append(valueOpts.RawValuesOverride, opts.ValueOpts.RawValuesOverride...)
 			}
 			if opts.CreateNamespace != nil {
 				createNamespace = *opts.CreateNamespace

--- a/cmd/helm/upgrade_test.go
+++ b/cmd/helm/upgrade_test.go
@@ -45,7 +45,7 @@ func TestUpgradeCmd(t *testing.T) {
 	if err := chartutil.SaveDir(cfile, tmpChart); err != nil {
 		t.Fatalf("Error creating chart for upgrade: %v", err)
 	}
-	ch, err := loader.Load(chartPath)
+	ch, err := loader.Load(chartPath, loader.LoadOptions{})
 	if err != nil {
 		t.Fatalf("Error loading chart: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestUpgradeCmd(t *testing.T) {
 	if err := chartutil.SaveDir(cfile, tmpChart); err != nil {
 		t.Fatalf("Error creating chart: %v", err)
 	}
-	ch, err = loader.Load(chartPath)
+	ch, err = loader.Load(chartPath, loader.LoadOptions{})
 	if err != nil {
 		t.Fatalf("Error loading updated chart: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestUpgradeCmd(t *testing.T) {
 		t.Fatalf("Error creating chart: %v", err)
 	}
 	var ch2 *chart.Chart
-	ch2, err = loader.Load(chartPath)
+	ch2, err = loader.Load(chartPath, loader.LoadOptions{})
 	if err != nil {
 		t.Fatalf("Error loading updated chart: %v", err)
 	}
@@ -362,7 +362,7 @@ func prepareMockRelease(releaseName string, t *testing.T) (func(n string, v int,
 	if err := chartutil.SaveDir(cfile, tmpChart); err != nil {
 		t.Fatalf("Error creating chart for upgrade: %v", err)
 	}
-	ch, err := loader.Load(chartPath)
+	ch, err := loader.Load(chartPath, loader.LoadOptions{})
 	if err != nil {
 		t.Fatalf("Error loading chart: %v", err)
 	}

--- a/internal/experimental/registry/cache.go
+++ b/internal/experimental/registry/cache.go
@@ -142,7 +142,7 @@ func (cache *Cache) FetchReference(ref *Reference) (*CacheRefSummary, error) {
 			if err != nil {
 				return &r, err
 			}
-			ch, err := loader.LoadArchive(bytes.NewBuffer(contentBytes))
+			ch, err := loader.LoadArchive(bytes.NewBuffer(contentBytes), loader.LoadOptions{})
 			if err != nil {
 				return &r, err
 			}

--- a/pkg/action/dependency.go
+++ b/pkg/action/dependency.go
@@ -45,7 +45,7 @@ func NewDependency() *Dependency {
 
 // List executes 'helm dependency list'.
 func (d *Dependency) List(chartpath string, out io.Writer) error {
-	c, err := loader.Load(chartpath)
+	c, err := loader.Load(chartpath, loader.LoadOptions{})
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func (d *Dependency) dependencyStatus(chartpath string, dep *chart.Dependency, p
 	case len(archives) == 1:
 		archive := archives[0]
 		if _, err := os.Stat(archive); err == nil {
-			c, err := loader.Load(archive)
+			c, err := loader.Load(archive, loader.LoadOptions{})
 			if err != nil {
 				return "corrupt"
 			}
@@ -167,7 +167,7 @@ func (d *Dependency) printMissing(chartpath string, out io.Writer, reqs []*chart
 		if !fi.IsDir() && filepath.Ext(f) != ".tgz" {
 			continue
 		}
-		c, err := loader.Load(f)
+		c, err := loader.Load(f, loader.LoadOptions{})
 		if err != nil {
 			fmt.Fprintf(out, "WARNING: %q is not a chart.\n", f)
 			continue

--- a/pkg/action/package.go
+++ b/pkg/action/package.go
@@ -55,7 +55,7 @@ func NewPackage() *Package {
 
 // Run executes 'helm package' against the given chart and returns the path to the packaged chart.
 func (p *Package) Run(path string, vals map[string]interface{}) (string, error) {
-	ch, err := loader.LoadDir(path)
+	ch, err := loader.LoadDir(path, loader.LoadOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/action/show.go
+++ b/pkg/action/show.go
@@ -66,7 +66,7 @@ func NewShow(output ShowOutputFormat) *Show {
 // Run executes 'helm show' against the given release.
 func (s *Show) Run(chartpath string) (string, error) {
 	var out strings.Builder
-	chrt, err := loader.Load(chartpath)
+	chrt, err := loader.Load(chartpath, loader.LoadOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -50,6 +50,8 @@ type Chart struct {
 
 	parent       *Chart
 	dependencies []*Chart
+
+	ChartExtender ChartExtender `json:"-"`
 }
 
 type CRD struct {

--- a/pkg/chart/chart_extender.go
+++ b/pkg/chart/chart_extender.go
@@ -1,0 +1,7 @@
+package chart
+
+type ChartExtender interface {
+	SetupChart(c *Chart) error
+	AfterLoad() error
+	MakeValues(inputVals map[string]interface{}) (map[string]interface{}, error)
+}

--- a/pkg/chart/loader/archive.go
+++ b/pkg/chart/loader/archive.go
@@ -39,12 +39,12 @@ var drivePathPattern = regexp.MustCompile(`^[a-zA-Z]:/`)
 type FileLoader string
 
 // Load loads a chart
-func (l FileLoader) Load() (*chart.Chart, error) {
-	return LoadFile(string(l))
+func (l FileLoader) Load(opts LoadOptions) (*chart.Chart, error) {
+	return LoadFile(string(l), opts)
 }
 
 // LoadFile loads from an archive file.
-func LoadFile(name string) (*chart.Chart, error) {
+func LoadFile(name string, opts LoadOptions) (*chart.Chart, error) {
 	if fi, err := os.Stat(name); err != nil {
 		return nil, err
 	} else if fi.IsDir() {
@@ -62,7 +62,7 @@ func LoadFile(name string) (*chart.Chart, error) {
 		return nil, err
 	}
 
-	c, err := LoadArchive(raw)
+	c, err := LoadArchive(raw, opts)
 	if err != nil {
 		if err == gzip.ErrHeader {
 			return nil, fmt.Errorf("file '%s' does not appear to be a valid chart file (details: %s)", name, err)
@@ -184,11 +184,11 @@ func LoadArchiveFiles(in io.Reader) ([]*BufferedFile, error) {
 }
 
 // LoadArchive loads from a reader containing a compressed tar archive.
-func LoadArchive(in io.Reader) (*chart.Chart, error) {
+func LoadArchive(in io.Reader, opts LoadOptions) (*chart.Chart, error) {
 	files, err := LoadArchiveFiles(in)
 	if err != nil {
 		return nil, err
 	}
 
-	return LoadFiles(files)
+	return LoadFiles(files, opts)
 }

--- a/pkg/chart/loader/directory.go
+++ b/pkg/chart/loader/directory.go
@@ -34,14 +34,14 @@ import (
 type DirLoader string
 
 // Load loads the chart
-func (l DirLoader) Load() (*chart.Chart, error) {
-	return LoadDir(string(l))
+func (l DirLoader) Load(opts LoadOptions) (*chart.Chart, error) {
+	return LoadDir(string(l), opts)
 }
 
 // LoadDir loads from a directory.
 //
 // This loads charts only from directories.
-func LoadDir(dir string) (*chart.Chart, error) {
+func LoadDir(dir string, opts LoadOptions) (*chart.Chart, error) {
 	topdir, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, err
@@ -111,5 +111,5 @@ func LoadDir(dir string) (*chart.Chart, error) {
 		return c, err
 	}
 
-	return LoadFiles(files)
+	return LoadFiles(files, opts)
 }

--- a/pkg/chartutil/coalesce.go
+++ b/pkg/chartutil/coalesce.go
@@ -35,6 +35,14 @@ import (
 //	- A chart has access to all of the variables for it, as well as all of
 //		the values destined for its dependencies.
 func CoalesceValues(chrt *chart.Chart, vals map[string]interface{}) (Values, error) {
+	if chrt.ChartExtender != nil {
+		if newVals, err := chrt.ChartExtender.MakeValues(vals); err != nil {
+			return vals, err
+		} else {
+			vals = newVals
+		}
+	}
+
 	v, err := copystructure.Copy(vals)
 	if err != nil {
 		return vals, err

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -470,7 +470,7 @@ spec:
 
 // CreateFrom creates a new chart, but scaffolds it from the src chart.
 func CreateFrom(chartfile *chart.Metadata, dest, src string) error {
-	schart, err := loader.Load(src)
+	schart, err := loader.Load(src, loader.LoadOptions{})
 	if err != nil {
 		return errors.Wrapf(err, "could not load %s", src)
 	}

--- a/pkg/chartutil/create_test.go
+++ b/pkg/chartutil/create_test.go
@@ -41,7 +41,7 @@ func TestCreate(t *testing.T) {
 
 	dir := filepath.Join(tdir, "foo")
 
-	mychart, err := loader.LoadDir(c)
+	mychart, err := loader.LoadDir(c, loader.LoadOptions{})
 	if err != nil {
 		t.Fatalf("Failed to load newly created chart %q: %s", c, err)
 	}
@@ -89,7 +89,7 @@ func TestCreateFrom(t *testing.T) {
 
 	dir := filepath.Join(tdir, "foo")
 	c := filepath.Join(tdir, cf.Name)
-	mychart, err := loader.LoadDir(c)
+	mychart, err := loader.LoadDir(c, loader.LoadOptions{})
 	if err != nil {
 		t.Fatalf("Failed to load newly created chart %q: %s", c, err)
 	}

--- a/pkg/chartutil/dependencies_test.go
+++ b/pkg/chartutil/dependencies_test.go
@@ -27,7 +27,7 @@ import (
 
 func loadChart(t *testing.T, path string) *chart.Chart {
 	t.Helper()
-	c, err := loader.Load(path)
+	c, err := loader.Load(path, loader.LoadOptions{})
 	if err != nil {
 		t.Fatalf("failed to load testdata: %s", err)
 	}

--- a/pkg/chartutil/save_test.go
+++ b/pkg/chartutil/save_test.go
@@ -70,7 +70,7 @@ func TestSave(t *testing.T) {
 				t.Fatalf("Expected %q to end with .tgz", where)
 			}
 
-			c2, err := loader.LoadFile(where)
+			c2, err := loader.LoadFile(where, loader.LoadOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -99,7 +99,7 @@ func TestSave(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to save: %s", err)
 			}
-			c2, err = loader.LoadFile(where)
+			c2, err = loader.LoadFile(where, loader.LoadOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -229,7 +229,7 @@ func TestSaveDir(t *testing.T) {
 		t.Fatalf("Failed to save: %s", err)
 	}
 
-	c2, err := loader.LoadDir(tmp + "/ahab")
+	c2, err := loader.LoadDir(tmp+"/ahab", loader.LoadOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cli/values/options.go
+++ b/pkg/cli/values/options.go
@@ -30,12 +30,10 @@ import (
 )
 
 type Options struct {
-	ValueFiles        []string
-	RawValues         []map[string]interface{}
-	StringValues      []string
-	Values            []string
-	FileValues        []string
-	RawValuesOverride []map[string]interface{}
+	ValueFiles   []string
+	StringValues []string
+	Values       []string
+	FileValues   []string
 }
 
 // MergeValues merges values from files specified via -f/--values and directly
@@ -57,10 +55,6 @@ func (opts *Options) MergeValues(p getter.Providers) (map[string]interface{}, er
 		}
 		// Merge with the previous map
 		base = mergeMaps(base, currentMap)
-	}
-
-	for _, rawValues := range opts.RawValues {
-		base = mergeMaps(base, rawValues)
 	}
 
 	// User specified a value via --set
@@ -86,10 +80,6 @@ func (opts *Options) MergeValues(p getter.Providers) (map[string]interface{}, er
 		if err := strvals.ParseIntoFile(value, base, reader); err != nil {
 			return nil, errors.Wrap(err, "failed parsing --set-file data")
 		}
-	}
-
-	for _, rawValues := range opts.RawValuesOverride {
-		base = mergeMaps(base, rawValues)
 	}
 
 	return base, nil

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -196,7 +196,7 @@ func (m *Manager) loadChartDir() (*chart.Chart, error) {
 	} else if !fi.IsDir() {
 		return nil, errors.New("only unpacked charts can be updated")
 	}
-	return loader.LoadDir(m.ChartPath)
+	return loader.LoadDir(m.ChartPath, loader.LoadOptions{})
 }
 
 // resolve takes a list of dependencies and translates them into an exact version to download.
@@ -245,7 +245,7 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 		if dep.Repository == "" {
 			fmt.Fprintf(m.Out, "Dependency %s did not declare a repository. Assuming it exists in the charts directory\n", dep.Name)
 			chartPath := filepath.Join(tmpPath, dep.Name)
-			ch, err := loader.LoadDir(chartPath)
+			ch, err := loader.LoadDir(chartPath, loader.LoadOptions{})
 			if err != nil {
 				return fmt.Errorf("Unable to load chart: %v", err)
 			}
@@ -365,7 +365,7 @@ func (m *Manager) safeDeleteDep(name, dir string) error {
 		return err
 	}
 	for _, fname := range files {
-		ch, err := loader.LoadFile(fname)
+		ch, err := loader.LoadFile(fname, loader.LoadOptions{})
 		if err != nil {
 			fmt.Fprintf(m.Out, "Could not verify %s for deletion: %s (Skipping)", fname, err)
 			continue
@@ -692,7 +692,7 @@ func tarFromLocalDir(chartpath, name, repo, version string) (string, error) {
 		return "", err
 	}
 
-	ch, err := loader.LoadDir(origPath)
+	ch, err := loader.LoadDir(origPath, loader.LoadOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -48,7 +48,7 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 	}
 
 	// Load chart and parse templates, based on tiller/release_server
-	chart, err := loader.Load(linter.ChartDir)
+	chart, err := loader.Load(linter.ChartDir, loader.LoadOptions{})
 
 	chartLoaded := linter.RunLinterRule(support.ErrorSev, path, err)
 

--- a/pkg/provenance/sign.go
+++ b/pkg/provenance/sign.go
@@ -317,7 +317,7 @@ func messageBlock(chartpath string) (*bytes.Buffer, error) {
 	}
 
 	// Load the archive into memory.
-	chart, err := loader.LoadFile(chartpath)
+	chart, err := loader.LoadFile(chartpath, loader.LoadOptions{})
 	if err != nil {
 		return b, err
 	}

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -176,7 +176,7 @@ func (r *ChartRepository) saveIndexFile() error {
 
 func (r *ChartRepository) generateIndex() error {
 	for _, path := range r.ChartPaths {
-		ch, err := loader.Load(path)
+		ch, err := loader.Load(path, loader.LoadOptions{})
 		if err != nil {
 			return err
 		}

--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -262,7 +262,7 @@ func IndexDirectory(dir, baseURL string) (*IndexFile, error) {
 			parentURL = path.Join(baseURL, parentDir)
 		}
 
-		c, err := loader.Load(arch)
+		c, err := loader.Load(arch, loader.LoadOptions{})
 		if err != nil {
 			// Assume this is not a chart.
 			continue


### PR DESCRIPTION
 - Patched loader.Load function to accept ChartExtender-interfaced object and factory to create extender for subcharts.
 - ChartExtender allows adding extra templates and values, generation of Chart.yaml.