### PR TITLE
[helm for werf] Fix manifest corrupted by Helm when `|-` is used in t…

### DIFF
--- a/pkg/releaseutil/manifest.go
+++ b/pkg/releaseutil/manifest.go
@@ -53,6 +53,8 @@ func SplitManifests(bigFile string) map[string]string {
 		}
 
 		d = strings.TrimSpace(d)
+		d += "\n"
+
 		res[fmt.Sprintf(tpl, count)] = d
 		count = count + 1
 	}


### PR DESCRIPTION
…he end of the template

Refs https://github.com/werf/werf/issues/2304