### PR TITLE
[v2.17.0][helm for werf] Remove errPending on upgrade

### DIFF
--- a/pkg/tiller/release_update.go
+++ b/pkg/tiller/release_update.go
@@ -98,7 +98,7 @@ func (s *ReleaseServer) prepareUpdate(req *services.UpdateReleaseRequest) (*rele
 	// pessimistic lock.
 	sc := lastRelease.Info.Status.Code
 	if sc == release.Status_PENDING_INSTALL || sc == release.Status_PENDING_UPGRADE || sc == release.Status_PENDING_ROLLBACK {
-		return nil, nil, errPending
+		//return nil, nil, errPending
 	}
 
 	// Increment revision count. This is passed to templates, and also stored on


### PR DESCRIPTION
errPending on upgrade could occur when some deploy has been interrupted by a signal.

In this case helm leave release in inconsistent state which could not be healed by automatical redeploy.

Werf uses own distributed release locking by release name using Kubernetes configmap annotations to synchronize multiple deploy processes. Werf implementation supports interrupting of werf-deploy process by some signal.

https://github.com/helm/helm/issues/8987