### PR TITLE
[v3.4.0][helm for werf] Remove errPending on upgrade

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -160,7 +160,7 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 
 	// Concurrent `helm upgrade`s will either fail here with `errPending` or when creating the release with "already exists". This should act as a pessimistic lock.
 	if lastRelease.Info.Status.IsPending() {
-		return nil, nil, errPending
+		//return nil, nil, errPending
 	}
 
 	var currentRelease *release.Release


### PR DESCRIPTION
errPending on upgrade could occur when some deploy has been interrupted by a signal.

In this case helm leave release in inconsistent state which could not be healed by automatical redeploy.

Werf uses own distributed release locking by release name using Kubernetes configmap annotations to synchronize multiple deploy processes. Werf implementation supports interrupting of werf-deploy process by some signal.

https://github.com/helm/helm/issues/8987