### PR TITLE
[helm for werf] Refactor LoadOptions passing: use global loader.GlobalLoadOptions variable

### DIFF
--- a/cmd/helm/chart_save.go
+++ b/cmd/helm/chart_save.go
@@ -35,14 +35,6 @@ not change the item as it exists in the cache.
 `
 
 func newChartSaveCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
-	return NewChartSaveCmd(cfg, out, ChartSaveCmdOptions{})
-}
-
-type ChartSaveCmdOptions struct {
-	LoadOptions loader.LoadOptions
-}
-
-func NewChartSaveCmd(cfg *action.Configuration, out io.Writer, opts ChartSaveCmdOptions) *cobra.Command {
 	return &cobra.Command{
 		Use:    "save [path] [ref]",
 		Short:  "save a chart directory",
@@ -58,7 +50,7 @@ func NewChartSaveCmd(cfg *action.Configuration, out io.Writer, opts ChartSaveCmd
 				return err
 			}
 
-			ch, err := loader.Load(path, opts.LoadOptions)
+			ch, err := loader.Load(path)
 			if err != nil {
 				return err
 			}

--- a/cmd/helm/create_test.go
+++ b/cmd/helm/create_test.go
@@ -48,7 +48,7 @@ func TestCreateCmd(t *testing.T) {
 		t.Fatalf("chart is not directory")
 	}
 
-	c, err := loader.LoadDir(cname, loader.LoadOptions{})
+	c, err := loader.LoadDir(cname)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestCreateStarterCmd(t *testing.T) {
 		t.Fatalf("chart is not directory")
 	}
 
-	c, err := loader.LoadDir(cname, loader.LoadOptions{})
+	c, err := loader.LoadDir(cname)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +162,7 @@ func TestCreateStarterAbsoluteCmd(t *testing.T) {
 		t.Fatalf("chart is not directory")
 	}
 
-	c, err := loader.LoadDir(cname, loader.LoadOptions{})
+	c, err := loader.LoadDir(cname)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/helm/exports.go
+++ b/cmd/helm/exports.go
@@ -32,12 +32,12 @@ var (
 	NewVerifyCmd     = newVerifyCmd
 	NewVersionCmd    = newVersionCmd
 	NewChartCmd      = newChartCmd
+	NewShowCmd       = newShowCmd
 
 	// NOTE: following commands has additional options param and defined in corresponding command files
 	//NewTemplateCmd   = newTemplateCmd
 	//NewInstallCmd    = newInstallCmd
 	//NewUpgradeCmd    = newUpgradeCmd
-	//NewShowCmd       = newShowCmd
 
 	LoadPlugins = loadPlugins
 )

--- a/cmd/helm/package_test.go
+++ b/cmd/helm/package_test.go
@@ -187,7 +187,7 @@ func TestSetAppVersion(t *testing.T) {
 	} else if fi.Size() == 0 {
 		t.Errorf("file %q has zero bytes.", chartPath)
 	}
-	ch, err := loader.Load(chartPath, loader.LoadOptions{})
+	ch, err := loader.Load(chartPath)
 	if err != nil {
 		t.Fatalf("unexpected error loading packaged chart: %v", err)
 	}

--- a/cmd/helm/show.go
+++ b/cmd/helm/show.go
@@ -21,12 +21,11 @@ import (
 	"io"
 	"log"
 
-	"helm.sh/helm/v3/pkg/chart/loader"
-
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v3/cmd/helm/require"
 	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart/loader"
 )
 
 const showDesc = `
@@ -54,14 +53,6 @@ of the README file
 `
 
 func newShowCmd(out io.Writer) *cobra.Command {
-	return NewShowCmd(out, ShowCmdOptions{})
-}
-
-type ShowCmdOptions struct {
-	LoadOptions loader.LoadOptions
-}
-
-func NewShowCmd(out io.Writer, opts ShowCmdOptions) *cobra.Command {
 	client := action.NewShow(action.ShowAll)
 
 	showCommand := &cobra.Command{
@@ -89,7 +80,7 @@ func NewShowCmd(out io.Writer, opts ShowCmdOptions) *cobra.Command {
 		ValidArgsFunction: validArgsFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowAll
-			output, err := runShow(args, client, opts.LoadOptions)
+			output, err := runShow(args, client)
 			if err != nil {
 				return err
 			}
@@ -106,7 +97,7 @@ func NewShowCmd(out io.Writer, opts ShowCmdOptions) *cobra.Command {
 		ValidArgsFunction: validArgsFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowValues
-			output, err := runShow(args, client, opts.LoadOptions)
+			output, err := runShow(args, client)
 			if err != nil {
 				return err
 			}
@@ -123,7 +114,7 @@ func NewShowCmd(out io.Writer, opts ShowCmdOptions) *cobra.Command {
 		ValidArgsFunction: validArgsFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowChart
-			output, err := runShow(args, client, opts.LoadOptions)
+			output, err := runShow(args, client)
 			if err != nil {
 				return err
 			}
@@ -140,7 +131,7 @@ func NewShowCmd(out io.Writer, opts ShowCmdOptions) *cobra.Command {
 		ValidArgsFunction: validArgsFunc,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client.OutputFormat = action.ShowReadme
-			output, err := runShow(args, client, opts.LoadOptions)
+			output, err := runShow(args, client)
 			if err != nil {
 				return err
 			}
@@ -179,7 +170,7 @@ func addShowFlags(subCmd *cobra.Command, client *action.Show) {
 	}
 }
 
-func runShow(args []string, client *action.Show, loadOpts loader.LoadOptions) (string, error) {
+func runShow(args []string, client *action.Show) (string, error) {
 	debug("Original chart version: %q", client.Version)
 	if client.Version == "" && client.Devel {
 		debug("setting version to >0.0.0-0")
@@ -188,8 +179,8 @@ func runShow(args []string, client *action.Show, loadOpts loader.LoadOptions) (s
 
 	var cp string
 	var err error
-	if loadOpts.LocateChartFunc != nil {
-		cp, err = loadOpts.LocateChartFunc(args[0], settings)
+	if loader.GlobalLoadOptions.LocateChartFunc != nil {
+		cp, err = loader.GlobalLoadOptions.LocateChartFunc(args[0], settings)
 	} else {
 		cp, err = client.ChartPathOptions.LocateChart(args[0], settings)
 	}

--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -29,8 +29,6 @@ import (
 
 	"helm.sh/helm/v3/pkg/postrender"
 
-	"helm.sh/helm/v3/pkg/chart/loader"
-
 	"github.com/spf13/cobra"
 
 	"helm.sh/helm/v3/cmd/helm/require"
@@ -54,7 +52,6 @@ func newTemplateCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 }
 
 type TemplateCmdOptions struct {
-	LoadOptions  loader.LoadOptions
 	PostRenderer postrender.PostRenderer
 	ValueOpts    *values.Options
 }
@@ -91,7 +88,7 @@ func NewTemplateCmd(cfg *action.Configuration, out io.Writer, opts TemplateCmdOp
 			client.ClientOnly = !validate
 			client.APIVersions = chartutil.VersionSet(extraAPIs)
 			client.IncludeCRDs = includeCrds
-			rel, err := runInstall(args, client, valueOpts, out, opts.LoadOptions)
+			rel, err := runInstall(args, client, valueOpts, out)
 
 			if err != nil && !settings.Debug {
 				if rel != nil {

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -68,7 +68,6 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 }
 
 type UpgradeCmdOptions struct {
-	LoadOptions     loader.LoadOptions
 	PostRenderer    postrender.PostRenderer
 	ValueOpts       *values.Options
 	CreateNamespace *bool
@@ -153,7 +152,7 @@ func NewUpgradeCmd(cfg *action.Configuration, out io.Writer, opts UpgradeCmdOpti
 					instClient.SubNotes = client.SubNotes
 					instClient.Description = client.Description
 
-					rel, err := runInstall(args, instClient, valueOpts, out, opts.LoadOptions)
+					rel, err := runInstall(args, instClient, valueOpts, out)
 					if err != nil {
 						return err
 					}
@@ -170,8 +169,8 @@ func NewUpgradeCmd(cfg *action.Configuration, out io.Writer, opts UpgradeCmdOpti
 
 			var chartPath string
 			var err error
-			if opts.LoadOptions.LocateChartFunc != nil {
-				chartPath, err = opts.LoadOptions.LocateChartFunc(args[1], settings)
+			if loader.GlobalLoadOptions.LocateChartFunc != nil {
+				chartPath, err = loader.GlobalLoadOptions.LocateChartFunc(args[1], settings)
 			} else {
 				chartPath, err = client.ChartPathOptions.LocateChart(args[1], settings)
 			}
@@ -179,13 +178,13 @@ func NewUpgradeCmd(cfg *action.Configuration, out io.Writer, opts UpgradeCmdOpti
 				return err
 			}
 
-			vals, err := valueOpts.MergeValues(getter.All(settings), opts.LoadOptions.ReadFileFunc)
+			vals, err := valueOpts.MergeValues(getter.All(settings), loader.GlobalLoadOptions.ReadFileFunc)
 			if err != nil {
 				return err
 			}
 
 			// Check chart dependencies to make sure all are present in /charts
-			ch, err := loader.Load(chartPath, opts.LoadOptions)
+			ch, err := loader.Load(chartPath)
 			if err != nil {
 				return err
 			}

--- a/cmd/helm/upgrade_test.go
+++ b/cmd/helm/upgrade_test.go
@@ -45,7 +45,7 @@ func TestUpgradeCmd(t *testing.T) {
 	if err := chartutil.SaveDir(cfile, tmpChart); err != nil {
 		t.Fatalf("Error creating chart for upgrade: %v", err)
 	}
-	ch, err := loader.Load(chartPath, loader.LoadOptions{})
+	ch, err := loader.Load(chartPath)
 	if err != nil {
 		t.Fatalf("Error loading chart: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestUpgradeCmd(t *testing.T) {
 	if err := chartutil.SaveDir(cfile, tmpChart); err != nil {
 		t.Fatalf("Error creating chart: %v", err)
 	}
-	ch, err = loader.Load(chartPath, loader.LoadOptions{})
+	ch, err = loader.Load(chartPath)
 	if err != nil {
 		t.Fatalf("Error loading updated chart: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestUpgradeCmd(t *testing.T) {
 		t.Fatalf("Error creating chart: %v", err)
 	}
 	var ch2 *chart.Chart
-	ch2, err = loader.Load(chartPath, loader.LoadOptions{})
+	ch2, err = loader.Load(chartPath)
 	if err != nil {
 		t.Fatalf("Error loading updated chart: %v", err)
 	}
@@ -362,7 +362,7 @@ func prepareMockRelease(releaseName string, t *testing.T) (func(n string, v int,
 	if err := chartutil.SaveDir(cfile, tmpChart); err != nil {
 		t.Fatalf("Error creating chart for upgrade: %v", err)
 	}
-	ch, err := loader.Load(chartPath, loader.LoadOptions{})
+	ch, err := loader.Load(chartPath)
 	if err != nil {
 		t.Fatalf("Error loading chart: %v", err)
 	}

--- a/internal/experimental/registry/cache.go
+++ b/internal/experimental/registry/cache.go
@@ -142,7 +142,7 @@ func (cache *Cache) FetchReference(ref *Reference) (*CacheRefSummary, error) {
 			if err != nil {
 				return &r, err
 			}
-			ch, err := loader.LoadArchive(bytes.NewBuffer(contentBytes), loader.LoadOptions{})
+			ch, err := loader.LoadArchive(bytes.NewBuffer(contentBytes))
 			if err != nil {
 				return &r, err
 			}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -76,7 +76,7 @@ func (r *Resolver) Resolve(reqs []*chart.Dependency, repoNames map[string]string
 
 			// The version of the chart locked will be the version of the chart
 			// currently listed in the file system within the chart.
-			ch, err := loader.LoadDir(chartpath, loader.LoadOptions{})
+			ch, err := loader.LoadDir(chartpath)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/action/dependency.go
+++ b/pkg/action/dependency.go
@@ -46,7 +46,7 @@ func NewDependency() *Dependency {
 
 // List executes 'helm dependency list'.
 func (d *Dependency) List(chartpath string, out io.Writer) error {
-	c, err := loader.Load(chartpath, loader.LoadOptions{})
+	c, err := loader.Load(chartpath)
 	if err != nil {
 		return err
 	}
@@ -150,7 +150,7 @@ func (d *Dependency) dependencyStatus(chartpath string, dep *chart.Dependency, p
 // support legacy behavior, and should be removed in Helm 4.
 func statArchiveForStatus(archive string, dep *chart.Dependency) string {
 	if _, err := os.Stat(archive); err == nil {
-		c, err := loader.Load(archive, loader.LoadOptions{})
+		c, err := loader.Load(archive)
 		if err != nil {
 			return "corrupt"
 		}
@@ -208,7 +208,7 @@ func (d *Dependency) printMissing(chartpath string, out io.Writer, reqs []*chart
 		if !fi.IsDir() && filepath.Ext(f) != ".tgz" {
 			continue
 		}
-		c, err := loader.Load(f, loader.LoadOptions{})
+		c, err := loader.Load(f)
 		if err != nil {
 			fmt.Fprintf(out, "WARNING: %q is not a chart.\n", f)
 			continue

--- a/pkg/action/package.go
+++ b/pkg/action/package.go
@@ -57,7 +57,7 @@ func NewPackage() *Package {
 
 // Run executes 'helm package' against the given chart and returns the path to the packaged chart.
 func (p *Package) Run(path string, vals map[string]interface{}) (string, error) {
-	ch, err := loader.LoadDir(path, loader.LoadOptions{})
+	ch, err := loader.LoadDir(path)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/action/show.go
+++ b/pkg/action/show.go
@@ -70,7 +70,7 @@ func NewShow(output ShowOutputFormat) *Show {
 // Run executes 'helm show' against the given release.
 func (s *Show) Run(chartpath string) (string, error) {
 	if s.chart == nil {
-		chrt, err := loader.Load(chartpath, loader.LoadOptions{})
+		chrt, err := loader.Load(chartpath)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/chart/loader/archive.go
+++ b/pkg/chart/loader/archive.go
@@ -39,12 +39,16 @@ var drivePathPattern = regexp.MustCompile(`^[a-zA-Z]:/`)
 type FileLoader string
 
 // Load loads a chart
-func (l FileLoader) Load(opts LoadOptions) (*chart.Chart, error) {
-	return LoadFile(string(l), opts)
+func (l FileLoader) Load(options LoadOptions) (*chart.Chart, error) {
+	return LoadFileWithOptions(string(l), options)
 }
 
 // LoadFile loads from an archive file.
-func LoadFile(name string, opts LoadOptions) (*chart.Chart, error) {
+func LoadFile(name string) (*chart.Chart, error) {
+	return LoadFileWithOptions(name, *GlobalLoadOptions)
+}
+
+func LoadFileWithOptions(name string, options LoadOptions) (*chart.Chart, error) {
 	if fi, err := os.Stat(name); err != nil {
 		return nil, err
 	} else if fi.IsDir() {
@@ -62,7 +66,7 @@ func LoadFile(name string, opts LoadOptions) (*chart.Chart, error) {
 		return nil, err
 	}
 
-	c, err := LoadArchive(raw, opts)
+	c, err := LoadArchiveWithOptions(raw, options)
 	if err != nil {
 		if err == gzip.ErrHeader {
 			return nil, fmt.Errorf("file '%s' does not appear to be a valid chart file (details: %s)", name, err)
@@ -186,11 +190,16 @@ func LoadArchiveFiles(in io.Reader) ([]*BufferedFile, error) {
 }
 
 // LoadArchive loads from a reader containing a compressed tar archive.
-func LoadArchive(in io.Reader, opts LoadOptions) (*chart.Chart, error) {
+func LoadArchive(in io.Reader) (*chart.Chart, error) {
+	return LoadArchiveWithOptions(in, *GlobalLoadOptions)
+}
+
+// LoadArchive loads from a reader containing a compressed tar archive.
+func LoadArchiveWithOptions(in io.Reader, options LoadOptions) (*chart.Chart, error) {
 	files, err := LoadArchiveFiles(in)
 	if err != nil {
 		return nil, err
 	}
 
-	return LoadFiles(files, opts)
+	return LoadFiles(files, options)
 }

--- a/pkg/chart/loader/directory.go
+++ b/pkg/chart/loader/directory.go
@@ -37,14 +37,18 @@ var utf8bom = []byte{0xEF, 0xBB, 0xBF}
 type DirLoader string
 
 // Load loads the chart
-func (l DirLoader) Load(opts LoadOptions) (*chart.Chart, error) {
-	return LoadDir(string(l), opts)
+func (l DirLoader) Load(options LoadOptions) (*chart.Chart, error) {
+	return LoadDirWithOptions(string(l), options)
 }
 
 // LoadDir loads from a directory.
 //
 // This loads charts only from directories.
-func LoadDir(dir string, opts LoadOptions) (*chart.Chart, error) {
+func LoadDir(dir string) (*chart.Chart, error) {
+	return LoadDirWithOptions(dir, *GlobalLoadOptions)
+}
+
+func LoadDirWithOptions(dir string, options LoadOptions) (*chart.Chart, error) {
 	topdir, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, err
@@ -67,13 +71,13 @@ func LoadDir(dir string, opts LoadOptions) (*chart.Chart, error) {
 	files := []*BufferedFile{}
 	topdir += string(filepath.Separator)
 
-	if opts.LoadDirFunc != nil {
-		if res, err := opts.LoadDirFunc(dir); err != nil {
+	if options.LoadDirFunc != nil {
+		if res, err := options.LoadDirFunc(dir); err != nil {
 			return nil, fmt.Errorf("unable to load files from dir %s: %s", dir, err)
 		} else {
 			files = res
 		}
-		return LoadFiles(files, opts)
+		return LoadFiles(files, options)
 	}
 
 	walk := func(name string, fi os.FileInfo, err error) error {
@@ -125,5 +129,5 @@ func LoadDir(dir string, opts LoadOptions) (*chart.Chart, error) {
 		return c, err
 	}
 
-	return LoadFiles(files, opts)
+	return LoadFiles(files, options)
 }

--- a/pkg/chartutil/create.go
+++ b/pkg/chartutil/create.go
@@ -488,7 +488,7 @@ var Stderr io.Writer = os.Stderr
 
 // CreateFrom creates a new chart, but scaffolds it from the src chart.
 func CreateFrom(chartfile *chart.Metadata, dest, src string) error {
-	schart, err := loader.Load(src, loader.LoadOptions{})
+	schart, err := loader.Load(src)
 	if err != nil {
 		return errors.Wrapf(err, "could not load %s", src)
 	}

--- a/pkg/chartutil/create_test.go
+++ b/pkg/chartutil/create_test.go
@@ -41,7 +41,7 @@ func TestCreate(t *testing.T) {
 
 	dir := filepath.Join(tdir, "foo")
 
-	mychart, err := loader.LoadDir(c, loader.LoadOptions{})
+	mychart, err := loader.LoadDir(c)
 	if err != nil {
 		t.Fatalf("Failed to load newly created chart %q: %s", c, err)
 	}
@@ -89,7 +89,7 @@ func TestCreateFrom(t *testing.T) {
 
 	dir := filepath.Join(tdir, "foo")
 	c := filepath.Join(tdir, cf.Name)
-	mychart, err := loader.LoadDir(c, loader.LoadOptions{})
+	mychart, err := loader.LoadDir(c)
 	if err != nil {
 		t.Fatalf("Failed to load newly created chart %q: %s", c, err)
 	}

--- a/pkg/chartutil/dependencies_test.go
+++ b/pkg/chartutil/dependencies_test.go
@@ -27,7 +27,7 @@ import (
 
 func loadChart(t *testing.T, path string) *chart.Chart {
 	t.Helper()
-	c, err := loader.Load(path, loader.LoadOptions{})
+	c, err := loader.Load(path)
 	if err != nil {
 		t.Fatalf("failed to load testdata: %s", err)
 	}

--- a/pkg/chartutil/save_test.go
+++ b/pkg/chartutil/save_test.go
@@ -68,7 +68,7 @@ func TestSave(t *testing.T) {
 				t.Fatalf("Expected %q to end with .tgz", where)
 			}
 
-			c2, err := loader.LoadFile(where, loader.LoadOptions{})
+			c2, err := loader.LoadFile(where)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -97,7 +97,7 @@ func TestSave(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to save: %s", err)
 			}
-			c2, err = loader.LoadFile(where, loader.LoadOptions{})
+			c2, err = loader.LoadFile(where)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -227,7 +227,7 @@ func TestSaveDir(t *testing.T) {
 		t.Fatalf("Failed to save: %s", err)
 	}
 
-	c2, err := loader.LoadDir(tmp+"/ahab", loader.LoadOptions{})
+	c2, err := loader.LoadDir(tmp + "/ahab")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/downloader/manager.go
+++ b/pkg/downloader/manager.go
@@ -222,7 +222,7 @@ func (m *Manager) loadChartDir() (*chart.Chart, error) {
 	} else if !fi.IsDir() {
 		return nil, errors.New("only unpacked charts can be updated")
 	}
-	return loader.LoadDir(m.ChartPath, loader.LoadOptions{})
+	return loader.LoadDir(m.ChartPath)
 }
 
 // resolve takes a list of dependencies and translates them into an exact version to download.
@@ -271,7 +271,7 @@ func (m *Manager) downloadAll(deps []*chart.Dependency) error {
 		if dep.Repository == "" {
 			fmt.Fprintf(m.Out, "Dependency %s did not declare a repository. Assuming it exists in the charts directory\n", dep.Name)
 			chartPath := filepath.Join(tmpPath, dep.Name)
-			ch, err := loader.LoadDir(chartPath, loader.LoadOptions{})
+			ch, err := loader.LoadDir(chartPath)
 			if err != nil {
 				return fmt.Errorf("Unable to load chart: %v", err)
 			}
@@ -391,7 +391,7 @@ func (m *Manager) safeDeleteDep(name, dir string) error {
 		return err
 	}
 	for _, fname := range files {
-		ch, err := loader.LoadFile(fname, loader.LoadOptions{})
+		ch, err := loader.LoadFile(fname)
 		if err != nil {
 			fmt.Fprintf(m.Out, "Could not verify %s for deletion: %s (Skipping)", fname, err)
 			continue
@@ -788,7 +788,7 @@ func tarFromLocalDir(chartpath, name, repo, version string) (string, error) {
 		return "", err
 	}
 
-	ch, err := loader.LoadDir(origPath, loader.LoadOptions{})
+	ch, err := loader.LoadDir(origPath)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/lint/rules/dependencies.go
+++ b/pkg/lint/rules/dependencies.go
@@ -31,7 +31,7 @@ import (
 //
 // See https://github.com/helm/helm/issues/7910
 func Dependencies(linter *support.Linter) {
-	c, err := loader.LoadDir(linter.ChartDir, loader.LoadOptions{})
+	c, err := loader.LoadDir(linter.ChartDir)
 	if !linter.RunLinterRule(support.ErrorSev, "", validateChartFormat(err)) {
 		return
 	}

--- a/pkg/lint/rules/template.go
+++ b/pkg/lint/rules/template.go
@@ -53,7 +53,7 @@ func Templates(linter *support.Linter, values map[string]interface{}, namespace 
 	}
 
 	// Load chart and parse templates
-	chart, err := loader.Load(linter.ChartDir, loader.LoadOptions{})
+	chart, err := loader.Load(linter.ChartDir)
 
 	chartLoaded := linter.RunLinterRule(support.ErrorSev, fpath, err)
 

--- a/pkg/provenance/sign.go
+++ b/pkg/provenance/sign.go
@@ -317,7 +317,7 @@ func messageBlock(chartpath string) (*bytes.Buffer, error) {
 	}
 
 	// Load the archive into memory.
-	chart, err := loader.LoadFile(chartpath, loader.LoadOptions{})
+	chart, err := loader.LoadFile(chartpath)
 	if err != nil {
 		return b, err
 	}

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -176,7 +176,7 @@ func (r *ChartRepository) saveIndexFile() error {
 
 func (r *ChartRepository) generateIndex() error {
 	for _, path := range r.ChartPaths {
-		ch, err := loader.Load(path, loader.LoadOptions{})
+		ch, err := loader.Load(path)
 		if err != nil {
 			return err
 		}

--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -285,7 +285,7 @@ func IndexDirectory(dir, baseURL string) (*IndexFile, error) {
 			parentURL = path.Join(baseURL, parentDir)
 		}
 
-		c, err := loader.Load(arch, loader.LoadOptions{})
+		c, err := loader.Load(arch)
 		if err != nil {
 			// Assume this is not a chart.
 			continue


### PR DESCRIPTION
This change will ease fetching of origin helm codebase from the upstream.