### PR TITLE
[werf for helm] Fix --create-namespace flag RBAC issue

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -309,7 +309,7 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 		if err != nil {
 			return nil, err
 		}
-		if _, err := i.cfg.KubeClient.Create(resourceList); err != nil && !apierrors.IsAlreadyExists(err) {
+		if _, err := i.cfg.KubeClient.CreateIfNotExists(resourceList); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -120,6 +120,20 @@ func (c *Client) IsReachable() error {
 	return nil
 }
 
+func (c *Client) CreateIfNotExists(resources ResourceList) (*Result, error) {
+	if c.Extender != nil {
+		if err := perform(resources, c.Extender.BeforeCreateResource); err != nil {
+			return nil, err
+		}
+	}
+
+	c.Log("creating %d resource(s)", len(resources))
+	if err := perform(resources, createResourceIfNotExists); err != nil {
+		return nil, err
+	}
+	return &Result{Created: resources}, nil
+}
+
 // Create creates Kubernetes resources specified in the resource list.
 func (c *Client) Create(resources ResourceList) (*Result, error) {
 	if c.Extender != nil {
@@ -443,6 +457,17 @@ func createResource(info *resource.Info) error {
 		return err
 	}
 	return info.Refresh(obj, true)
+}
+
+func createResourceIfNotExists(info *resource.Info) error {
+	_, err := resource.NewHelper(info.Client, info.Mapping).Get(info.Namespace, info.Name)
+	if apierrors.IsNotFound(err) {
+		return createResource(info)
+	} else if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func deleteResource(info *resource.Info) error {

--- a/pkg/kube/fake/printer.go
+++ b/pkg/kube/fake/printer.go
@@ -47,6 +47,11 @@ func (p *PrintingKubeClient) Create(resources kube.ResourceList) (*kube.Result, 
 	return &kube.Result{Created: resources}, nil
 }
 
+// Create prints the values of what would be created with a real KubeClient.
+func (p *PrintingKubeClient) CreateIfNotExists(resources kube.ResourceList) (*kube.Result, error) {
+	return p.Create(resources)
+}
+
 func (p *PrintingKubeClient) Wait(resources kube.ResourceList, _ time.Duration) error {
 	_, err := io.Copy(p.Out, bufferize(resources))
 	return err

--- a/pkg/kube/interface.go
+++ b/pkg/kube/interface.go
@@ -35,6 +35,8 @@ type DeleteOptions struct {
 type Interface interface {
 	// Create creates one or more resources.
 	Create(resources ResourceList) (*Result, error)
+	// Create creates one or more resources with resource existance check.
+	CreateIfNotExists(resources ResourceList) (*Result, error)
 
 	Wait(resources ResourceList, timeout time.Duration) error
 


### PR DESCRIPTION
Allow case when namespace already exists in the cluster and user does not have a permission to create namespaces. `helm install --create-namespace` would not try to create namespace in such case.

This change makes `--create-namespace` flag behaviour moreidempotent.