### PR TITLE
fix: fixed broken 3 way merge when previous release was failed

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -182,22 +182,14 @@ func (u *Upgrade) prepareUpgrade(name string, chart *chart.Chart, vals map[strin
 	}
 
 	isUpgrade := true
-
-	var currentRelease *release.Release
-	if lastRelease.Info.Status == release.StatusDeployed {
-		// no need to retrieve the last deployed release from storage as the last release is deployed
-		currentRelease = lastRelease
-	} else {
-		// finds the deployed release with the given name
-		currentRelease, err = u.cfg.Releases.Deployed(name)
-		if err != nil {
-			if errors.Is(err, driver.ErrNoDeployedReleases) &&
-				(lastRelease.Info.Status == release.StatusFailed || lastRelease.Info.Status == release.StatusSuperseded || lastRelease.Info.Status == release.StatusPendingInstall || lastRelease.Info.Status == release.StatusPendingUpgrade || lastRelease.Info.Status == release.StatusPendingRollback) {
-				currentRelease = lastRelease
-				isUpgrade = false
-			} else {
-				return nil, nil, err
-			}
+	currentRelease := lastRelease
+	_, err = u.cfg.Releases.Deployed(name)
+	if err != nil {
+		if errors.Is(err, driver.ErrNoDeployedReleases) &&
+			(lastRelease.Info.Status == release.StatusFailed || lastRelease.Info.Status == release.StatusSuperseded || lastRelease.Info.Status == release.StatusPendingInstall || lastRelease.Info.Status == release.StatusPendingUpgrade || lastRelease.Info.Status == release.StatusPendingRollback) {
+			isUpgrade = false
+		} else {
+			return nil, nil, err
 		}
 	}
 


### PR DESCRIPTION
Create a patch from previous release revision no matter succeeded it was or failed, rather than always creating a patch from the previous succeeded release revision.

Affect following cases:
- https://github.com/werf/werf/issues/3461
- https://github.com/werf/werf/issues/3462
